### PR TITLE
Notify users of new transaction, require acceptance

### DIFF
--- a/notifications.php
+++ b/notifications.php
@@ -139,9 +139,34 @@ function removeNotification($notification_id) {
     global $mysqli;
 
     $sql = "DELETE FROM notifications
-            WHERE notification_id=?";
+            WHERE notification_id = ?";
 
     $mysqli->execute_query($sql, [$notification_id]);
+}
+
+/*
+Adds a new notification to a given user's feed about a transaction
+    Params
+        $transaction_id - The unique identifier for the transaction being modified
+        $user_id - The user that should be notified
+
+TODO: Does not check if the user exists. Does it need to?
+*/
+function addApprovalRequestNotification($transaction_id, $user_id)
+{
+    global $mysqli;
+
+    $sql = "INSERT INTO notifications
+                        (user_id, type, transaction_id)
+            VALUES      (?, approval_request, ?)";
+
+    $response = $mysqli->execute_query($sql, [$user_id, $transaction_id]);
+
+    if ($response !== true) {
+        //Error with insertion of notif
+        http_response_code(HTTP_INTERNAL_SERVER_ERROR);
+        return;
+    }
 }
 
 ?>

--- a/transaction_approval.php
+++ b/transaction_approval.php
@@ -1,0 +1,144 @@
+<?php
+
+include_once('templates/connection.php');
+include_once('templates/cookies.php');
+include_once('templates/constants.php');
+
+/*
+Transaction Approval PHP Endpoint
+    POC: njones9
+
+    Primary Functions:  getTransactions($user_id)
+                        getTransaction($transaction_id)
+
+                        addNewTransaction($json_obj)
+                        updateExistingTransaction($json_obj)
+
+                        deleteTransaction($json_obj)
+
+    Helper Functions:   encapsulateTransactionData($row)
+                        validateTransactionData($json_obj)
+                        checkParticipantsForUser($array, $user_id)
+
+
+    Notes:
+
+        In the current state, this DOES NOT integrate with the debt computation
+        mechanisms. JSON objects could use some better notation for follow-on usage.
+
+        Includes some error checking, but is not safe against malicious usage.
+
+    TODO:
+
+        The updateExistingTransactions function needs some attention. Not all
+        mutable values have setters.
+
+        The Notes section provides some egregious flaws in data security.
+
+    Structure:
+
+        Main entrypoint at the top of file. Called with each endpoint access. 
+
+        Incoming request is triaged and dispatched to functions which exist
+        at the bottom of the file.
+*/
+
+###################
+#                 #
+# MAIN ENTRYPOINT #
+#                 #
+###################
+
+
+
+/*
+PUT Request
+    - Requires URL parameter for transaction_id
+*/
+if ($_SERVER["REQUEST_METHOD"] == "PUT")
+{
+
+    if (!empty($_PUT)) 
+    {
+        if (is_string($_PUT) && json_decode($_PUT, true)) {
+            updateExistingTransaction($_PUT);
+        }
+    }
+}
+
+
+
+
+/*
+Sets all approvals to false for a given transaction
+    Params
+        $transaction_id - The unique identifier for the transaction being modified
+    Returns
+        $boolval($response) - Boolean whether update was successful
+*/
+function resetTransactionApprovals($transaction_id)
+{
+    global $mysqli;
+    
+    $sql = "UPDATE  transaction_participants
+            SET     has_approved = ?
+            WHERE   transaction_id = ?";
+
+    
+    $response = $mysqli->execute_query($sql, [false, $transaction_id]);
+
+    return boolval($response);
+}
+
+/*
+Approves a transaction for a given transaction
+    Params
+        $transaction_id - The unique identifier for the transaction being modified
+*/
+function approveTransaction($transaction_id) 
+{
+    global $mysqli;
+
+    $user_id = intval(validateSessionID());
+
+    // Unathorized, no user_id associated with cookie
+    if ($user_id === 0)
+    {
+        http_response_code(HTTP_UNAUTHORIZED);
+        return;
+    }
+
+    //Users can only approve their own transactions
+    //SQL will handle if the user isn't actually a participant
+    $sql = "UPDATE  transaction_participants
+            SET     has_approved = ?
+            WHERE   transaction_id = ? AND user_id = ?";
+
+    $mysqli->execute_query($sql, [true, $transaction_id, $user_id]);
+
+    return;
+}
+
+/*
+Checks whether all transaction participants have approved of the transaction
+    Params
+        $transaction_id - The unique identifier for the transaction being modified
+    
+    Returns
+        true - All users in $transaction_id has approved
+        false - Some users have still yet to approve $transaction_id
+*/
+function checkTransactionStatus($transaction_id)
+{
+    global $mysqli;
+
+    $sql = "SELECT  ALL     user_id
+            FROM            transaction_participants
+            WHERE           has_approved = false AND transaction_id = ?";
+
+    $response = $mysqli->execute_query($sql, [$transaction_id]);
+
+    return !boolval($response->num_rows);
+}
+
+?>

--- a/transactions.php
+++ b/transactions.php
@@ -4,6 +4,8 @@ include_once('templates/connection.php');
 include_once('templates/cookies.php');
 include_once('templates/constants.php');
 
+include_once('notifications.php');
+
 /*
 Transactions PHP Endpoint
     POC: njones9
@@ -88,7 +90,7 @@ elseif ($_SERVER["REQUEST_METHOD"] == "POST")
 }
 
 /*
-UPDATE Request
+PUT Request
     - Requires JSON object in body
 */
 elseif ($_SERVER["REQUEST_METHOD"] == "PUT")
@@ -376,6 +378,9 @@ function addNewTransaction($data)
             http_response_code(HTTP_INTERNAL_SERVER_ERROR);
             return;
         }
+        
+        //Send out notifications for approval
+        addApprovalRequestNotification($transaction_id, $participant);
     }
     
     return;
@@ -421,8 +426,6 @@ function updateExistingTransaction($data)
     }
 
     
-
-
     $sql = "UPDATE  transactions
             SET     transaction_name = ?,
                     transaction_date = ?,


### PR DESCRIPTION
Upon submission of a new transaction, notifications will be generated for all participants. PHP endpoint within `transaction_approval.php` for accepting using a given transaction_id.