### PR TITLE
CFG-206 Fix List Alignment

### DIFF
--- a/react_source/components/GroupInfo.js
+++ b/react_source/components/GroupInfo.js
@@ -91,7 +91,7 @@ export default function GroupInfo(props) {
             
             <View style={styles.groupInfo} >
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between', maxWidth: '100%', width: 'auto'}}>
-                    <View style={globals.styles.listIconAndTextContainer }>
+                    <View style={{ flexDirection: 'row' } }>
                         <ChangeableIcon iconPath={iconPath} name={groupName} groupID={props.id} />
                         <Text style={{ ...globals.styles.h1, ...styles.groupName}}>{groupName}</Text>
                     </View>
@@ -104,9 +104,9 @@ export default function GroupInfo(props) {
                     </Button>
                     
                 </View>
-                <View style={styles.listContainer}>
+                <View style={globals.styles.listContainer}>
                     <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                        <Text style={{ ...globals.styles.h3, ...styles.listTitle}}>Members</Text>
+                        <Text style={globals.styles.listTitle}>Members</Text>
                         <Button id="groupPage_addMember" style={{ ...globals.styles.formButton, ...{ width: '10em', margin: '.45em .75em 0' } }} onClick={inviteMember}>
                             <SVGIcon src={InviteIcon} style={styles.icon} />
                             <label htmlFor="groupPage_addMember" style={globals.styles.buttonLabel}>
@@ -124,9 +124,9 @@ export default function GroupInfo(props) {
 
                 </View>
 
-                <View style={styles.listContainer}>
+                <View style={globals.styles.listContainer}>
                     <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                        <Text style={{ ...globals.styles.h3, ...styles.listTitle }}>Transactions</Text>
+                        <Text style={globals.styles.listTitle }>Transactions</Text>
                         <Button id="groupPage_newExpense" style={{ ...globals.styles.formButton, ...{ width: '10em', margin: '.45em .75em 0' } }} onClick={addExpense}>
                             <label htmlFor="groupPage_newExpense" style={globals.styles.buttonLabel}>
                                 + NEW EXPENSE
@@ -247,36 +247,33 @@ function MemberListItem({ id, name, owed, pending, group_id, icon_path }) {
 
     return (
         <>
-            <Link to={'/profile/' + id}>
+            <Link to={'/profile/' + id} style={globals.styles.listItemRow}>
                 
-                <View style={globals.styles.listItemRow}>
-                    <Image
-                        style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em' } }}
-                        source={icon_path !== null ? decodeURI(icon_path) : globals.getDefaultUserIcon(name)}
-                    />
-                    <Text style={{ ...globals.styles.listText, ...{ fontStyle: pending ? 'italic' : "inherit", paddingLeft: '.25em' } }}>{name}</Text>
-                    {currUserID != id &&
+                <Image
+                    style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em' } }}
+                    source={icon_path !== null ? decodeURI(icon_path) : globals.getDefaultUserIcon(name)}
+                />
+                <Text style={{ ...globals.styles.listText, ...{ fontStyle: pending ? 'italic' : "inherit", paddingLeft: '.25em' } }}>{name}</Text>
+                {currUserID != id &&
 
-                        <Button style={{ ...globals.styles.transparentButton, ...{ width: '1.75em', margin: 0, marginTop: '.25em' } }} aria-label="Kick User" onClick={kickMember}>
-                            <SVGIcon src={KickIcon} style={styles.kickButton} />
-                        </Button>
-                    }
-                </View>
-               
-            </Link>
-            <Link to={'/profile/' + id}>
+                    <Button style={{ ...globals.styles.transparentButton, ...{ width: '1.75em', margin: 0, marginTop: '.25em' } }} aria-label="Kick User" onClick={kickMember}>
+                        <SVGIcon src={KickIcon} style={styles.kickButton} />
+                    </Button>
+                }
                 
-                <View style={{
-                    ...globals.styles.listItemColumn,
-                    ...{ alignItems: 'flex-end' }
-                    }}>
-                    {!pending &&
-                        <>
-                            <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
-                            <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(owed / 100).toFixed(2)}</Text>
-                        </>
-                    }
-                </View> 
+            </Link>
+            <Link to={'/profile/' + id} style={{
+                ...globals.styles.listItemColumn,
+                ...{ alignItems: 'flex-end' }
+            }}>
+                
+                {!pending &&
+                    <>
+                        <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
+                        <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(owed / 100).toFixed(2)}</Text>
+                    </>
+                }
+               
             </Link>
         
         </>
@@ -348,27 +345,6 @@ const styles = {
         marginTop: '1em',
         margin: `1em min(5em, 5vw)`,
         padding: `2.5em min(2.5em, 2.5vw)`
-    },
-    listContainer: {
-        height: 'auto',
-        marginTop: '2em',
-        boxShadow: '0px 0px 5px 5px #eee',
-        borderRadius: '1em',
-        backgroundColor: globals.COLOR_WHITE,
-    },
-    listHeader: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        borderStyle: 'none none solid',
-        borderWidth: '1px',
-        borderColor: globals.COLOR_OFF_WHITE,
-        paddingBottom: '.5em'
-    },
-    listTitle: {
-        color: globals.COLOR_GRAY,
-        fontWeight: 600,
-        paddingLeft: '1em',
-        paddingBottom: '1.5em' 
     },
     icon: {
         fill: globals.COLOR_WHITE,

--- a/react_source/components/GroupsList.js
+++ b/react_source/components/GroupsList.js
@@ -72,15 +72,14 @@ function GroupList() {
         //List has been returned, render it
         return (
             <View style={globals.styles.list}>
-                <View style={globals.styles.listLabel} >
-                    <Text style={{ ...globals.styles.h3, ...globals.styles.listText}}>GROUP NAME</Text>
-                    <View style={{ width: 'auto', paddingRight: '.5em', minWidth: '5em', alignItems: 'flex-end' }}>
-                        <Text style={{ ...globals.styles.h3, ...globals.styles.listText}}>BALANCE</Text>
-                    </View>
-                </View>
+
+                <Text style={globals.styles.listHeader}>GROUP NAME</Text>
+                <Text style={{ ...globals.styles.listHeader, ...{ alignItems: 'center' } }}>BALANCE</Text>
+
                 {groupItems}
 
             </View>
+            
         );
     }
 }
@@ -92,24 +91,28 @@ function GroupItem(props) {
     color = props.owed == 0 ? { color: globals.COLOR_GRAY } : color;
 
     return (
+        <>
+            <Link to={'/groups/' + props.id}>
 
-        <Link to={'/groups/' + props.id}>
-            <View style={props.border ? globals.styles.listItemSeperator : globals.styles.listItem} >
-
-                <View style={globals.styles.listIconAndTextContainer}>
+                <View style={globals.styles.listItemRow }>
                     <Image
-                        style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em'}}}
+                        style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em' } }}
                         source={props.icon_path !== null ? decodeURI(props.icon_path) : globals.getDefaultGroupIcon(props.name)}
                     />
-                    <Text style={{ ...globals.styles.listText, ...{paddingLeft: '.25em'}}}>{props.name}</Text>
+                    <Text style={{ ...globals.styles.listText, ...{ paddingLeft: '.25em' } }}>{props.name}</Text>
                 </View>
-                <View style={{ width: 'auto', paddingRight: '.5em', marginVertical: 'auto', minWidth: '5em', alignItems: 'center' }}>
-                    <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color}}>{text}</Text>
-                    <Text style={{ ...globals.styles.listText, ...color}}>${Math.abs(props.owed / 100).toFixed(2)}</Text>
-                </View>
+                
+            </Link>
+            <Link to={'/groups/' + props.id} >
 
-            </View>
-        </Link>
+                <View style={globals.styles.listItemColumn}>
+                        <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
+                        <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(props.owed / 100).toFixed(2)}</Text>
+                    </View>
+
+            </Link>
+        </>
+        
 
     );
 }
@@ -123,8 +126,8 @@ async function buildGroups() {
     if (groups === null) return groupList;
 
     for (let i = 0; i < groups.length; i++) {
-                    
-        groupList.push(<GroupItem key={i} border={i > 0} name={groups[i].group_name} id={groups[i].group_id} owed={groups[i].debt} icon_path={groups[i].icon_path} />);
+        for (let j = 0; j < 10; j++)   
+            groupList.push(<GroupItem key={i} border={j > 0} name={groups[i].group_name} id={groups[i].group_id} owed={groups[i].debt} icon_path={groups[i].icon_path} />);
     }
            
     return groupList;

--- a/react_source/components/GroupsList.js
+++ b/react_source/components/GroupsList.js
@@ -92,24 +92,20 @@ function GroupItem(props) {
 
     return (
         <>
-            <Link to={'/groups/' + props.id}>
+            <Link to={'/groups/' + props.id} style={globals.styles.listItemRow}>
 
-                <View style={globals.styles.listItemRow }>
-                    <Image
-                        style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em' } }}
-                        source={props.icon_path !== null ? decodeURI(props.icon_path) : globals.getDefaultGroupIcon(props.name)}
-                    />
-                    <Text style={{ ...globals.styles.listText, ...{ paddingLeft: '.25em' } }}>{props.name}</Text>
-                </View>
+                <Image
+                    style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em' } }}
+                    source={props.icon_path !== null ? decodeURI(props.icon_path) : globals.getDefaultGroupIcon(props.name)}
+                />
+                <Text style={{ ...globals.styles.listText, ...{ paddingLeft: '.25em' } }}>{props.name}</Text>
                 
             </Link>
-            <Link to={'/groups/' + props.id} >
-
-                <View style={globals.styles.listItemColumn}>
-                        <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
-                        <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(props.owed / 100).toFixed(2)}</Text>
-                    </View>
-
+            <Link to={'/groups/' + props.id} style={globals.styles.listItemColumn}>
+                
+                <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
+                <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(props.owed / 100).toFixed(2)}</Text>
+                    
             </Link>
         </>
         

--- a/react_source/components/GroupsList.js
+++ b/react_source/components/GroupsList.js
@@ -126,8 +126,7 @@ async function buildGroups() {
     if (groups === null) return groupList;
 
     for (let i = 0; i < groups.length; i++) {
-        for (let j = 0; j < 10; j++)   
-            groupList.push(<GroupItem key={i} border={j > 0} name={groups[i].group_name} id={groups[i].group_id} owed={groups[i].debt} icon_path={groups[i].icon_path} />);
+        groupList.push(<GroupItem key={i} name={groups[i].group_name} id={groups[i].group_id} owed={groups[i].debt} icon_path={groups[i].icon_path} />);
     }
            
     return groupList;

--- a/react_source/components/Profile.js
+++ b/react_source/components/Profile.js
@@ -154,12 +154,9 @@ export default function Profile(props) {
 
                 <View style={styles.listContainer}>
                     <Text style={{ ...globals.styles.h3, ...styles.listTitle}}>Groups in Common</Text>
-                    <View style={styles.listHeader} >
-
-                        <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600' }}>GROUP NAME</Text>
-
-                    </View>
-                    <View style={{ ...globals.styles.list, ...{ marginTop: '.25em', width: '100%', marginBottom: '1em' }}}>
+                   
+                    <View style={{ ...globals.styles.list, ...{ gridTemplateColumns : '100%', marginTop: '.25em', width: '100%', marginBottom: '1em' } }}>
+                        <Text style={globals.styles.smallListHeader}>GROUP NAME</Text>
                         {groups}
                     </View>
                 </View>
@@ -180,13 +177,9 @@ export default function Profile(props) {
                         </View>
                     </View>
                     
-                    <View style={styles.listHeader} >
-
-                        <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600' }}>TRANSACTION</Text>
-                        <Text style={{ color: globals.COLOR_GRAY, paddingRight: '2em' }}>DATE</Text>
-
-                    </View>
-                    <View style={{ ...globals.styles.list, ...{ marginTop: '.25em', width: '100%', marginBottom: '1em' }}}>
+                    <View style={{ ...globals.styles.list, ...{ marginTop: '.25em', width: '100%', marginBottom: '1em' } }}>
+                        <Text style={globals.styles.smallListHeader}>TRANSACTION</Text>
+                        <Text style={{ ...globals.styles.smallListHeader, ...{ alignItems: 'flex-end' } }}>DATE</Text>
                         {transactions}
                     </View>
 
@@ -299,7 +292,6 @@ function getTransactionList(transactionsJSON) {
         outputList.push(
             <TransactionListItem
                 key={i}
-                border={i > 0}
                 name={transactionsJSON[i].name}
                 id={transactionsJSON[i].transaction_id}
                 date={transactionsJSON[i].date}
@@ -312,25 +304,23 @@ function getTransactionList(transactionsJSON) {
     return outputList;
 }
 
-function GroupListItem({ id, name, icon_path, border }) {
+function GroupListItem({ id, name, icon_path }) {
     return (
 
         <Link to={'/groups/' + id}>
-            <View style={border ? globals.styles.listItemSeperator : globals.styles.listItem} >
-                <View style={globals.styles.listIconAndTextContainer}>
-                    <Image
-                        style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em'}}}
-                        source={icon_path !== null ? decodeURI(icon_path) : globals.getDefaultGroupIcon(name)}
-                    />
-                    <Text style={{ ...globals.styles.listText, ...{paddingLeft: '.25em'}}}>{name}</Text>
-                </View>
+            <View style={globals.styles.listItemRow}>
+                <Image
+                    style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em'}}}
+                    source={icon_path !== null ? decodeURI(icon_path) : globals.getDefaultGroupIcon(name)}
+                />
+                <Text style={{ ...globals.styles.listText, ...{paddingLeft: '.25em'}}}>{name}</Text>
             </View>
         </Link>
 
     );
 }
 
-function TransactionListItem({ id, name, date, user_debt, border, isApproved }) {
+function TransactionListItem({ id, name, date, user_debt, isApproved }) {
 
     const { pushModal, popModal } = useContext(ModalContext);
 
@@ -344,12 +334,19 @@ function TransactionListItem({ id, name, date, user_debt, border, isApproved }) 
 
     return (
 
-        <View style={{ ...border ? globals.styles.listItemSeperator : globals.styles.listItem, ...{cursor:'pointer'}}} onClick={viewTransaction} >
-
-            <Text style={{ ...globals.styles.listText, ...pendingItalic}}>{name}</Text>
-            <Text style={globals.styles.listText}>{date}</Text>
-
-        </View>
+      <>
+            <Text
+                style={{ ...globals.styles.listItemRow, ...globals.styles.listText, ...pendingItalic, ...{ cursor: 'pointer', minHeight: '2.5em' } }}
+                onClick={viewTransaction}>
+                {name}
+            </Text>
+            <Text
+                style={{ ...globals.styles.listItemRow, ...globals.styles.listText, ...{ cursor: 'pointer', justifyContent: 'flex-end' } }}
+                onClick={viewTransaction}>
+                {date}
+            </Text>
+      
+      </>
 
     );
 }

--- a/react_source/components/Profile.js
+++ b/react_source/components/Profile.js
@@ -125,7 +125,7 @@ export default function Profile(props) {
         <View style={{ flexDirection: 'row', height: '100%', flex: 1}}>
             <View style={styles.groupInfo} >
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between', maxWidth: '100%', width: 'auto'}}>
-                    <View style={globals.styles.listIconAndTextContainer}>
+                    <View style={{ flexDirection: 'row' }}>
                         <Image
                             style={{ ...globals.styles.listIcon, ...{ width: '3em', height: '3em' }}}
                             source={iconPath !== null ? decodeURI(iconPath) : globals.getDefaultUserIcon(username)}
@@ -143,17 +143,13 @@ export default function Profile(props) {
                         onAddFriend={verifyAddFriend}
                     />
                 </View>
-                <View style={styles.listContainer}>
-                    <Text style={{ ...globals.styles.h3, ...styles.listTitle}}>Email</Text>
-                    <View style={styles.listHeader} >
-
-                        <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600', paddingBottom: '1.5em' }}>{email}</Text>
-
-                    </View>
+                <View style={globals.styles.listContainer}>
+                    <Text style={globals.styles.listTitle}>Email</Text>
+                    <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600', paddingBottom: '1.5em' }}>{email}</Text>                    
                 </View>
 
-                <View style={styles.listContainer}>
-                    <Text style={{ ...globals.styles.h3, ...styles.listTitle}}>Groups in Common</Text>
+                <View style={globals.styles.listContainer}>
+                    <Text style={globals.styles.listTitle}>Groups in Common</Text>
                    
                     <View style={{ ...globals.styles.list, ...{ gridTemplateColumns : '100%', marginTop: '.25em', width: '100%', marginBottom: '1em' } }}>
                         <Text style={globals.styles.smallListHeader}>GROUP NAME</Text>
@@ -161,9 +157,9 @@ export default function Profile(props) {
                     </View>
                 </View>
 
-                <View style={styles.listContainer}>
+                <View style={globals.styles.listContainer}>
                     <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
-                        <Text style={{ ...globals.styles.h3, ...styles.listTitle }}>Transactions in Common</Text>
+                        <Text style={globals.styles.listTitle}>Transactions in Common</Text>
                         <View style={{ flexDirection: 'row' }}>
                             <View style={{ width: 'auto', paddingRight: '.5em', margin: 'auto 0', minWidth: '5em', alignItems: 'center' }}>
                                 <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color}}>{text}</Text>
@@ -215,7 +211,7 @@ function FriendInteractionButtons({isFriend, isPendingFriend, friendRequestCanAp
         if (friendRequestCanApprove) {
             // friend request has been sent to this user, options are to accept to reject request
             return (
-                <View>
+                <>
                     <Button
                         id="friend_rejectRequest"
                         style={{ ...globals.styles.formButton, ...styles.friendInteractionButton }}
@@ -237,7 +233,7 @@ function FriendInteractionButtons({isFriend, isPendingFriend, friendRequestCanAp
                             ACCEPT FRIEND REQUEST
                         </label>
                     </Button>
-                </View>
+                </>
             );
         }
         else {
@@ -307,14 +303,14 @@ function getTransactionList(transactionsJSON) {
 function GroupListItem({ id, name, icon_path }) {
     return (
 
-        <Link to={'/groups/' + id}>
-            <View style={globals.styles.listItemRow}>
-                <Image
-                    style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em'}}}
-                    source={icon_path !== null ? decodeURI(icon_path) : globals.getDefaultGroupIcon(name)}
-                />
-                <Text style={{ ...globals.styles.listText, ...{paddingLeft: '.25em'}}}>{name}</Text>
-            </View>
+        <Link to={'/groups/' + id} style={globals.styles.listItemRow}>
+            
+            <Image
+                style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em'}}}
+                source={icon_path !== null ? decodeURI(icon_path) : globals.getDefaultGroupIcon(name)}
+            />
+            <Text style={{ ...globals.styles.listText, ...{paddingLeft: '.25em'}}}>{name}</Text>
+            
         </Link>
 
     );
@@ -366,27 +362,6 @@ const styles = {
         width: 'auto',
         margin: `1em min(5em, 5vw)`,
         padding: '2.5em min(2.5em, 2.5vw)',
-    },
-    listContainer: {
-        height: 'auto',
-        marginTop: '2em',
-        boxShadow: '0px 0px 5px 5px #eee',
-        borderRadius: '1em',
-        backgroundColor: globals.COLOR_WHITE
-    },
-    listTitle: {
-        color: globals.COLOR_GRAY,
-        fontWeight: 600,
-        paddingLeft: '1em',
-        paddingBottom: '1.5em'
-    },
-    listHeader: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        borderStyle: 'none none solid',
-        borderWidth: '1px',
-        borderColor: '#eee',
-        paddingBottom: '.5em'
     },
     icon: {
         fill: globals.COLOR_WHITE,

--- a/react_source/components/SelfProfile.js
+++ b/react_source/components/SelfProfile.js
@@ -13,9 +13,6 @@ import EditProfile from "../modals/EditProfile.js";
 import ChangeableIcon from "./ChangeableIcon.js"
 import SVGIcon from "./SVGIcon.js";
 
-
-
-
 export default function SelfProfile(props) {
 
     const { pushModal, popModal } = useContext(ModalContext);
@@ -58,29 +55,29 @@ export default function SelfProfile(props) {
         <View style={{ flexDirection: 'row', height: '100%', flex: 1}}>
             <View style={styles.groupInfo} >
                 <View style={{ flexDirection: 'row', justifyContent: 'space-between', maxWidth: '100%', width: 'auto'}}>
-                    <View style={globals.styles.listIconAndTextContainer} >
+                    <View style={{ flexDirection: 'row' }} >
                         <ChangeableIcon iconPath={iconPath} name={username} />
                         <Text style={{ ...globals.styles.h1, ...styles.groupName}}>MY PROFILE</Text>
                     </View>
                 </View>
-                <View style={styles.list}>
-                    <View style={{ ...styles.listHeader, ...styles.listItem}}>
-                        <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600' }}>USERNAME</Text>
-                        <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600' }}>{username}</Text>
-                    </View>
-                    <View style={{ ...styles.listHeader, ...styles.listItemSeperator}}>
-                        <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600' }}>EMAIL</Text>
-                        <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600' }}>{email}</Text>
-                    </View>
-                    <View style={{ ...styles.listHeader, ...styles.listItemSeperator}}>
-                        <Button id="profile_editProfile" style={{ ...globals.styles.formButton, ...{ width: '15em', margin: 0, marginTop: '.25em' } }}  onClick={editProfile} >
-                           
-                            <label htmlFor="profile_editProfile" style={globals.styles.buttonLabel }>
-                                EDIT PROFILE
-                            </label>
-                        </Button>
-                    </View>
+                
+                <View style={styles.listHeader}>
+                    <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600' }}>USERNAME</Text>
+                    <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600' }}>{username}</Text>
                 </View>
+                <View style={styles.listHeader}>
+                    <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600' }}>EMAIL</Text>
+                    <Text style={{ color: globals.COLOR_GRAY, paddingLeft: '2em', fontWeight: '600' }}>{email}</Text>
+                </View>
+                <View style={{ ...styles.listHeader, ...{ borderWidth: 0 } }}>
+                    <Button id="profile_editProfile" style={{ ...globals.styles.formButton, ...{ width: '15em', margin: 0, marginTop: '.25em' } }}  onClick={editProfile} >
+                           
+                        <label htmlFor="profile_editProfile" style={globals.styles.buttonLabel }>
+                            EDIT PROFILE
+                        </label>
+                    </Button>
+                </View>
+                
             </View>
         </View>
     );
@@ -101,42 +98,13 @@ const styles = {
         margin: `1em min(5em, 5vw)`,
         padding: `2.5em min(2.5em, 2.5vw)`
     },
-    listItem: {
-        justifyContent: 'space-between',
-        alignItems: 'left',
-        flexDirection: 'row',
-        marginTop: '.5em',
-        paddingBottom: '.5em',
-        paddingLeft: '1em'
-
-    },
-    listItemSeperator: {
-        justifyContent: 'space-between',
-        alignItems: 'left',
-        flexDirection: 'row',
-        borderStyle: 'none',
-        borderTopStyle: 'solid',
-        borderWidth: '1px',
-        borderColor: '#eee',
-        paddingTop: '.5em',
-        paddingBottom: '.5em',
-        paddingLeft: '1em'
-
-    },
-    listContainer: {
-        flex:1,
-        marginTop: '2em',
-        boxShadow: '0px 0px 5px 5px #eee',
-        borderRadius: '1em',
-        backgroundColor: globals.COLOR_WHITE
-    },
     listHeader: {
         flexDirection: 'row',
         justifyContent: 'space-between',
-        borderStyle: 'none none solid',
-        borderWidth: '1px',
-        borderColor: '#eee',
-        paddingBottom: '.5em'
+        borderStyle: 'none none solid none',
+        borderWidth: '2px',
+        borderColor: globals.COLOR_OFF_WHITE,
+        padding: '.75em'
     },
     icon: {
         fill: globals.COLOR_WHITE,

--- a/react_source/components/SidebarFriendList.js
+++ b/react_source/components/SidebarFriendList.js
@@ -67,8 +67,8 @@ function SidebarFriendListItems(props) {
     let pendingItalic = props.isPending == 1 ? { fontStyle: 'italic' } : {};
 
     return (
-        <Button id={"sidebar_friend_" + props.name} style={{ ...props.border ? globals.styles.listItemSeperator : globals.styles.listItem, ...{ padding: 0 } }} onClick={() => props.setFriendID(props.id) }>
-            <View style={{...globals.styles.listIconAndTextContainer, ...{padding: '.25em 1em'}} }>
+        <Button id={"sidebar_friend_" + props.name} style={{ ...globals.styles.sidebarListItem, ...{ padding: 0 } }} onClick={() => props.setFriendID(props.id) }>
+            <View style={{...globals.styles.sidebarListItem, ...{padding: '.25em 1em'}} }>
                 <Image
                     style={{ ...globals.styles.listIcon, ...{ width: '1.25em', height: '1.25em'}}}
                     source={props.icon_path !== null ? decodeURI(props.icon_path) : globals.getDefaultUserIcon(props.name)}
@@ -94,7 +94,6 @@ async function buildSidebarFriendListItems(friendID, setFriendID)
 
         friendList.push(<SidebarFriendListItems
             key={i}
-            border={i > 0}
             name={friendJSON[i].username}
             id={friendJSON[i].user_id}
             icon_path={friendJSON[i].icon_path}

--- a/react_source/components/SidebarFriendList.js
+++ b/react_source/components/SidebarFriendList.js
@@ -55,9 +55,7 @@ export default function SidebarFriendList(props) {
                     </label>
                 </Button>
             </>
-
         );
-
     }
 }
 

--- a/react_source/components/SidebarGroupList.js
+++ b/react_source/components/SidebarGroupList.js
@@ -77,7 +77,6 @@ function GroupListItem(props) {
                 />
                 <label htmlFor={"sidebar_group_" + props.name} style={{ ...globals.styles.listText, ...{ paddingLeft: '.25em' }}}>{props.name}</label>
             </View>
-
         </Button>
     );
 }

--- a/react_source/components/SidebarGroupList.js
+++ b/react_source/components/SidebarGroupList.js
@@ -69,8 +69,8 @@ function GroupListItem(props) {
 
     return (
 
-        <Button id={"sidebar_group_" + props.name} style={{ ...props.border ? globals.styles.listItemSeperator : globals.styles.listItem, ...{ padding: 0 } }} onClick={() => props.setGroupID(props.id)} >
-            <View style={{...globals.styles.listIconAndTextContainer, ...{padding: '.25em 1em'}}}>
+        <Button id={"sidebar_group_" + props.name} style={{ ...globals.styles.sidebarListItem, ...{ padding: 0 } }} onClick={() => props.setGroupID(props.id)} >
+            <View style={{ ...globals.styles.sidebarListItem, ...{padding: '.25em 1em'}}}>
                 <Image
                     style={{ ...globals.styles.listIcon, ...{ width: '1.25em', height: '1.25em'}}}
                     source={props.icon_path !== null ? decodeURI(props.icon_path) : globals.getDefaultGroupIcon(props.name)}
@@ -94,7 +94,7 @@ async function buildGroups(groupID, setGroupID) {
         // update the currently selected group to display, if one is not already selected
         if (i == 0 && groupID == null) setGroupID(groups[i].group_id);
 
-        groupList.push(<GroupListItem key={i} border={i > 0} name={groups[i].group_name} id={groups[i].group_id} icon_path={groups[i].icon_path} setGroupID={setGroupID} />);
+        groupList.push(<GroupListItem key={i} name={groups[i].group_name} id={groups[i].group_id} icon_path={groups[i].icon_path} setGroupID={setGroupID} />);
     }
 
     return groupList;

--- a/react_source/components/SummaryFriendsList.js
+++ b/react_source/components/SummaryFriendsList.js
@@ -91,20 +91,18 @@ function SummaryFriendItem(props) {
 
     return (
         <>
-            <Link to={'/profile/' + props.id}>
-                <View style={globals.styles.listItemRow}>
-                    <Image
-                        style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em' } }}
-                        source={props.icon_path !== null ? decodeURI(props.icon_path) : globals.getDefaultUserIcon(props.name)}
-                    />
-                    <Text style={{ ...globals.styles.listText, ...{ paddingLeft: '.25em' } }}>{props.name}</Text>
-                </View>
+            <Link to={'/profile/' + props.id} style={globals.styles.listItemRow}>
+                
+                <Image
+                    style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em' } }}
+                    source={props.icon_path !== null ? decodeURI(props.icon_path) : globals.getDefaultUserIcon(props.name)}
+                />
+                <Text style={{ ...globals.styles.listText, ...{ paddingLeft: '.25em' } }}>{props.name}</Text>
+                
             </Link>
-            <Link to={'/profile/' + props.id}>
-                <View style={globals.styles.listItemColumn}>
-                    <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
-                    <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(props.owed / 100).toFixed(2)}</Text>
-                </View>
+            <Link to={'/profile/' + props.id} style={globals.styles.listItemColumn}>
+                <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
+                <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(props.owed / 100).toFixed(2)}</Text>
             </Link>
         </>
         

--- a/react_source/components/SummaryFriendsList.js
+++ b/react_source/components/SummaryFriendsList.js
@@ -126,7 +126,6 @@ async function buildFriends() {
         {
             friendList.push(<SummaryFriendItem
                 key={i}
-                border={i > 0}
                 name={friends[i].username}
                 id={friends[i].user_id}
                 icon_path={friends[i].icon_path}

--- a/react_source/components/SummaryFriendsList.js
+++ b/react_source/components/SummaryFriendsList.js
@@ -73,12 +73,9 @@ function FriendList() {
         // List has been parsed into SummaryFriendItem components, render it
         return (
             <View style={globals.styles.list}>
-                <View style={globals.styles.listLabel} >
-                    <Text style={{ ...globals.styles.h3, ...globals.styles.listText}}>USERNAME</Text>
-                    <View style={{ width: 'auto', paddingRight: '.5em', minWidth: '5em', alignItems: 'flex-end' }}>
-                        <Text style={{ ...globals.styles.h3, ...globals.styles.listText}}>BALANCE</Text>
-                    </View>
-                </View>
+                <Text style={globals.styles.listHeader}>USERNAME</Text>
+                <Text style={{ ...globals.styles.listHeader, ...{ alignItems: 'center' }}}>BALANCE</Text>
+               
                 {summaryFriendItems}
 
             </View>
@@ -93,23 +90,24 @@ function SummaryFriendItem(props) {
     color = props.owed == 0 ? { color: globals.COLOR_GRAY } : color;
 
     return (
-
-        <Link to={'/profile/' + props.id}>
-            <View style={props.border ? globals.styles.listItemSeperator : globals.styles.listItem} >
-                <View style={globals.styles.listIconAndTextContainer}>
+        <>
+            <Link to={'/profile/' + props.id}>
+                <View style={globals.styles.listItemRow}>
                     <Image
-                        style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em'}}}
+                        style={{ ...globals.styles.listIcon, ...{ marginLeft: '.75em', width: '2.5em', height: '2.5em' } }}
                         source={props.icon_path !== null ? decodeURI(props.icon_path) : globals.getDefaultUserIcon(props.name)}
                     />
-                    <Text style={{ ...globals.styles.listText, ...{paddingLeft: '.25em'}}}>{props.name}</Text>
+                    <Text style={{ ...globals.styles.listText, ...{ paddingLeft: '.25em' } }}>{props.name}</Text>
                 </View>
-                <View style={{ width: 'auto', paddingRight: '.5em', marginVertical: 'auto', minWidth: '5em', alignItems: 'center' }}>
-                    <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color}}>{text}</Text>
-                    <Text style={{ ...globals.styles.listText, ...color}}>${Math.abs(props.owed / 100).toFixed(2)}</Text>
+            </Link>
+            <Link to={'/profile/' + props.id}>
+                <View style={globals.styles.listItemColumn}>
+                    <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
+                    <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(props.owed / 100).toFixed(2)}</Text>
                 </View>
-
-            </View>
-        </Link>
+            </Link>
+        </>
+        
 
     );
 }

--- a/react_source/components/SummaryTransactionsList.js
+++ b/react_source/components/SummaryTransactionsList.js
@@ -57,12 +57,15 @@ function TransactionList() {
     } else {
         // List has been parsed into SummaryFriendItem components, render it
         return (
-            <View style={globals.styles.list}>
-                <View style={globals.styles.listLabel} >
-                    <Text style={{ ...globals.styles.h3, ...globals.styles.listText, ...{flexShrink:0}}}>TRANSACTION NAME</Text>
-                    <Text style={{ ...globals.styles.h5, ...globals.styles.listText, ...{flexShrink:0}}}>DATE</Text>
-                    <Text style={{ ...globals.styles.h5, ...globals.styles.listText, ...{flexShrink:0}}}>YOUR CONTRIBUTION</Text>
-                </View>
+            <View style={{
+                ...globals.styles.list,
+                ...{ gridTemplateColumns: '50% 30% 20%', }
+            }} >
+
+                <Text style={globals.styles.listHeader}>NAME</Text>
+                <Text style={globals.styles.listHeader}>DATE</Text>
+                <Text style={{ ...globals.styles.listHeader, ...{ alignItems: 'center' } }}>AMOUNT</Text>
+               
                 {summaryTransactionItems}
 
             </View>
@@ -84,20 +87,29 @@ function SummaryTransactionItem(props) {
     }
 
     return (
+        <>
+            
 
-        <View
-            style={{ ...props.border ? globals.styles.listItemSeperator : globals.styles.listItem, ...{flex: 'initial', cursor:'pointer'}}}
-            onClick={viewTransaction}
-        >
-
-            <Text style={{ ...globals.styles.listText, ...{paddingLeft: '.25em'}, ...pendingItalic}}>{props.name}</Text>
-            <Text style={{ ...globals.styles.listText, ...{paddingLeft: '.25em'}}}>{props.date}</Text>
-            <View style={{ width: 'auto', paddingRight: '.5em', marginVertical: 'auto', minWidth: '5em', alignItems: 'center' }}>
-                <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color}}>{text}</Text>
-                <Text style={{ ...globals.styles.listText, ...color}}>${Math.abs(props.debt / 100).toFixed(2)}</Text>
+            <Text
+                style={{ ...globals.styles.listText, ...globals.styles.listItemRow, ...pendingItalic, ...{ cursor: 'pointer' } }}
+                onClick={viewTransaction}>
+                {props.name}
+            </Text>
+            <Text
+                style={{ ...globals.styles.listText, ...globals.styles.listItemRow, ...{ cursor: 'pointer' } }}
+                onClick={viewTransaction}>
+                {props.date}
+            </Text>
+            <View
+                style={{ ...globals.styles.listItemColumn, ...{ cursor: 'pointer' } }}
+                onClick={viewTransaction}>
+                <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
+                <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(props.debt / 100).toFixed(2)}</Text>
             </View>
 
-        </View>
+            
+        </>
+        
 
     );
 }
@@ -116,10 +128,11 @@ async function buildTransactions(currUserID) {
         {
             continue;
         }
+
+        
         transactionList.push(
             <SummaryTransactionItem
                 key={i}
-                border={i > 0}
                 name={transactions[i].transaction_name}
                 id={transactions[i].transaction_id}
                 date={transactions[i].transaction_date}

--- a/react_source/modals/NewExpense.js
+++ b/react_source/modals/NewExpense.js
@@ -255,7 +255,7 @@ function SelectGroup() {
         }}}>
             <Text style={{ ...globals.styles.text, ...{ paddingTop: '1em' }}}>Which group is this transaction for?</Text>
 
-            <View style={{ ...globals.styles.list, ...{ alignItems: 'center', justifyContent: 'center', width: '100%' } }} >
+            <View style={{ ...globals.styles.list, ...{ gridTemplateColumns: '100%' } }} >
                 {groups}
             </View>
 
@@ -382,12 +382,10 @@ function SplitExpense() {
             </View>
            
 
-            <View style={{ ...globals.styles.list, ...{ width: '75%', alignItems: 'center' } }} >
+            <View style={{ ...globals.styles.list, ...{ gridTemplateColumns: '60% 40%', width: '75%' } }} >
                 {splitList}
             </View>
             
-            
-
 
             <View style={{ justifyContent: 'space-between', width: '75%', flexDirection: 'row' }}>
                 <Button id="newExpense_splitExpense_back" style={{ ...globals.styles.formButton, ...{ margin: '1em 0', width: '33%' } }} onClick={() => setPageNum(PAGES.SELECT_SPLIT)} >
@@ -426,14 +424,11 @@ function SplitListItem(props) {
         setReRender(reRender + 1);
     }
     
-   
-
     return (
-        
-        <View style={{ ...styles.listItem, ...{width: '100%'}}} >
 
-            <Text style={{ ...globals.styles.listText, ...{ margin: 'auto 0' }}}>{props.name}</Text>
-            <View style={{flexDirection: 'row', width: 'auto' }}>
+        <>
+            <Text style={{ ...globals.styles.listText, ...{ margin: 'auto 0' } }}>{props.name}</Text>
+            <View style={{ flexDirection: 'row', width: 'auto', justifySelf: 'flex-end' }}>
                 <Button id={"newExpense_splitExpense" + props.name + "_paid"}
                     style={{ width: 'auto', marginTop: '.25em' }}
                     onClick={updateButton} >
@@ -443,14 +438,12 @@ function SplitListItem(props) {
 
                 </Button>
 
-                <View style={{ width: '6em' }}>
-                    <input ref={inputRef} style={globals.styles.input} step={.01} type='number' placeholder={0} min={0}></input>
+                <View style={{ width: '5em' }}>
+                    <input ref={inputRef} style={{ ...globals.styles.input, ...{ width: '90%' }}} step={.01} type='number' placeholder={0} min={0}></input>
 
                 </View>
             </View>
-           
-           
-        </View>
+        </> 
         
     );
 }
@@ -468,7 +461,7 @@ async function buildGroups(setID, setPage) {
 
     for (let i = 0; i < groups.length; i++) {
         outputList.push(
-            <Button id={"newExpense_selectGroup_" + groups[i].group_name} style={{ ...globals.styles.formButton, ...{ margin: '.5em 0' } }} onClick={
+            <Button id={"newExpense_selectGroup_" + groups[i].group_name} style={{ ...globals.styles.formButton, ...{ justifySelf: 'center', margin: '.5em 0' } }} onClick={
             () => { 
                 setID(groups[i].group_id);
                 setPage(PAGES.SPLIT_EXPENSE);

--- a/react_source/modals/TransactionInfo.js
+++ b/react_source/modals/TransactionInfo.js
@@ -147,18 +147,20 @@ function ListItem({ id, name, owed, border, hasApproved }) {
     let pendingItalic = hasApproved == 0 ? { fontStyle: 'italic' } : {};
 
     return (
-
-        <Link to={'/profile/' + id}>
-            <View style={border ? globals.styles.listItemSeperator : globals.styles.listItem} >
-
-                <Text style={{ ...globals.styles.listText, ...pendingItalic }}>{name}</Text>
-                <View style={{ width: 'auto', paddingRight: '.5em', marginTop: '-.5em', marginBottom: '-.5em', minWidth: '5em', alignItems: 'center' }}>
-                    <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
-                    <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(owed / 100).toFixed(2)}</Text>
-                </View>
-
-            </View>
-        </Link>
+        <>
+            <Link to={'/profile/' + id} style={{ ...globals.styles.listItemRow, ...globals.styles.listText, ...pendingItalic }}>
+               {name}
+            </Link>
+            <Link to={'/profile/' + id} style={{
+                ...globals.styles.listItemColumn,
+                ...{ alignItems: 'flex-end' }
+            }}>
+                
+                <Text style={{ ...globals.styles.listText, ...{ fontSize: '.66em' }, ...color }}>{text}</Text>
+                <Text style={{ ...globals.styles.listText, ...color }}>${Math.abs(owed / 100).toFixed(2)}</Text>                
+            </Link>
+        </>
+        
 
     );
 }

--- a/react_source/utils/globals.js
+++ b/react_source/utils/globals.js
@@ -261,6 +261,13 @@ export const styles = {
         overflowY: 'auto',
         scrollbarWidth: 'thin',
     },
+    listContainer: {
+        height: 'auto',
+        marginTop: '2em',
+        boxShadow: '0px 0px 5px 5px #eee',
+        borderRadius: '1em',
+        backgroundColor: COLOR_WHITE,
+    },
     sidebarListItem: {
         flex: 'auto',
         height: 'auto',
@@ -304,18 +311,21 @@ export const styles = {
         borderWidth: '1px'
 
     },
-    listIconAndTextContainer: {
-        flex: 'auto',
-        flexDirection: 'row',
-        justifyContent: 'start',
-        alignItems: 'center'
-    },
+
     listText: {
         fontSize: '1.17em',
         paddingTop: 0,
         paddingBottom: 0,
         color: COLOR_GRAY,
         height:'auto',
+    },
+    listTitle: {
+        color: COLOR_GRAY,
+        fontWeight: 600,
+        padding: '.566em',
+        paddingLeft: '1em',
+        paddingBottom: '1.5em',
+        fontSize: '1.17em',
     },
     listHeader: {
         position: 'sticky',
@@ -349,29 +359,6 @@ export const styles = {
         aspectRatio: 1,
         borderRadius: '50%',
         boxShadow: '0px 0px 2px 2px #eee',
-    },
-    listItemSeperator: {
-        flex: 1,
-        height: 'auto',
-        padding: '.5em 1em',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        flexDirection: 'row',
-        borderStyle: 'none',
-        borderTopStyle: 'solid',
-        borderWidth: '1px',
-        borderColor: '#eee'
-
-    },
-    listLabel: {
-        minHeight: 'auto',
-        padding: 0,
-        position: 'sticky',
-        top: 0,
-        zIndex: 1,
-        backgroundColor: COLOR_WHITE,
-        flexDirection: 'row',
-        justifyContent: 'space-between',
     },
     h1: {
         padding: '1em',

--- a/react_source/utils/globals.js
+++ b/react_source/utils/globals.js
@@ -261,14 +261,14 @@ export const styles = {
         overflowY: 'auto',
         scrollbarWidth: 'thin',
     },
-    listItem: {
-        flex: 1,
+    sidebarListItem: {
+        flex: 'auto',
         height: 'auto',
         padding: '.5em 1em',
-        justifyContent: 'space-between',
+
+        justifyContent: 'flex-start',
         alignItems: 'center',
         flexDirection: 'row',
-        backgroundColor: COLOR_WHITE,
 
     },
     listItemRow: {
@@ -331,6 +331,18 @@ export const styles = {
         fontWeight: 'bolder',
         color: COLOR_GRAY,
         backgroundColor: COLOR_WHITE,  
+    },
+    smallListHeader: {
+        position: 'sticky',
+        zIndex: 1,
+        top: 0,
+        height: 'auto',
+        minHeight: '1em',
+        padding: '0 1em .5em',
+
+        fontSize: '.85em',
+        color: COLOR_GRAY,
+        backgroundColor: COLOR_WHITE,
     },
     listIcon: {
         flex: '0 0 auto',

--- a/react_source/utils/globals.js
+++ b/react_source/utils/globals.js
@@ -11,6 +11,7 @@ export const COLOR_WHITE            = "#FFF";
 export const COLOR_BLACK            = "#000";
 export const COLOR_GRAY             = "#777";
 export const COLOR_LIGHT_GRAY       = "#CCC";
+export const COLOR_OFF_WHITE        = "#EEE";
 export const COLOR_RED              = "#F00";
 
 export const COLOR_DISABLED         = '#66666633';
@@ -248,21 +249,17 @@ export const styles = {
     },
     list: {
         flex: 1,
-        width: '92%',
+        height: 'auto',
+        display: 'grid',
+        width: '90%',
+        gridTemplateColumns: '80% 20%',
+        gridAutoRows: 'min-content',
 
-        marginTop: '1em',
-        marginBottom: '1em',
-
-        justifyContent: 'flex-start',
-        alignItems: 'left',
         alignSelf: 'center',
-
-        backgroundColor: COLOR_WHITE,
+        margin: '.25em 0',
 
         overflowY: 'auto',
         scrollbarWidth: 'thin',
-
-
     },
     listItem: {
         flex: 1,
@@ -270,7 +267,41 @@ export const styles = {
         padding: '.5em 1em',
         justifyContent: 'space-between',
         alignItems: 'center',
-        flexDirection: 'row'
+        flexDirection: 'row',
+        backgroundColor: COLOR_WHITE,
+
+    },
+    listItemRow: {
+        flex: 'auto',
+        height: 'auto',
+        padding: '.5em 1em',
+
+        justifyContent: 'flex-start',
+        alignItems: 'center',
+        flexDirection: 'row',
+
+        backgroundColor: COLOR_WHITE,
+
+        borderStyle: 'solid none none',
+        borderColor: COLOR_OFF_WHITE,
+        borderWidth: '1px'
+
+    },
+    listItemColumn: {
+        flex: 'auto',
+        height: 'auto',
+        width: 'auto',
+        padding: '.5em 1em',
+
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        flexDirection: 'column',
+
+        backgroundColor: COLOR_WHITE,
+
+        borderStyle: 'solid none none',
+        borderColor: COLOR_OFF_WHITE,
+        borderWidth: '1px'
 
     },
     listIconAndTextContainer: {
@@ -285,6 +316,21 @@ export const styles = {
         paddingBottom: 0,
         color: COLOR_GRAY,
         height:'auto',
+    },
+    listHeader: {
+        position: 'sticky',
+        zIndex: 1,
+        top: 0,
+        height: 'auto',
+        minHeight: '1.25em',
+
+        margin: '-1px 0',
+        padding: '0 .566em',
+
+        fontSize: '1.17em',
+        fontWeight: 'bolder',
+        color: COLOR_GRAY,
+        backgroundColor: COLOR_WHITE,  
     },
     listIcon: {
         flex: '0 0 auto',


### PR DESCRIPTION
### Fix List Alignment
- Lists now use `display: grid` defaulting to an 80:20 split
- Removed need for differentiating styles based on position in list (`listItem` and `listItemSeperator` are gone)
- Changed styles to use `listItemRow` and `listItemColumn`
- List headers are now part of the list and use the `listHeader` style
- Sidebar lists now have their own style: `sidebarListItem`

#### listItemRow: align items horizontally, starting from the left.
#### listItemColumn: align items vertically, items are vertically centered.